### PR TITLE
escape file names in bash

### DIFF
--- a/edit-in-external-editor.js
+++ b/edit-in-external-editor.js
@@ -34,10 +34,10 @@ function bash(script) {
     let file = `${fm.basePath}/${draft.uuid}.md`;
 
     try {
-        bash(`open -n -W -a "${EDITOR}" ${file}`);
+        bash(`open -n -W -a "${EDITOR}" "${file}"`);
         draft.content = fm.readString(`/${draft.uuid}.md`);
         draft.update();
-        bash(`rm ${file}`);
+        bash(`rm "${file}"`);
     } catch (e) {
         alert(e);
         return;


### PR DESCRIPTION
I had to use double quotes to make sure file names with spaces didn't get garbled